### PR TITLE
renovate設定の追加

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":disableMajorUpdates",
+    ":timezone(Asia/Tokyo)",
+    ":combinePatchMinorReleases",
+    ":prHourlyLimitNone",
+    ":prConcurrentLimit10",
+    "group:recommended",
+    "group:allNonMajor"
+  ],
+  "schedule": ["after 9am on monday", "before 12am on monday"],
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "groupName": "dependencies (non-major)",
+      "rangeStrategy": "update-lockfile"
+    }
+  ]
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Chore: Renovateの設定を追加しました。メジャーアップデートは無効化され、タイムゾーンは東京に設定されています。パッチとマイナーリリースが組み合わせられ、PRの時間制限が解除され、同時に最大10個のPRが許可されます。依存関係ダッシュボードが有効化され、依存関係と開発用依存関係のアップデート戦略がロックファイル更新に設定されました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->