### PR TITLE
import/no-restricted-pathsルールで@t3-oss/env-nextjsを特定のパスのファイルからでしかimportできないようにする

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -92,6 +92,18 @@
           }
         ]
       }
+    ],
+    "import/no-restricted-paths": [
+      "error",
+      {
+        "zones": [
+          {
+            "target": "./**/!(env).ts?(x)",
+            "from": ["node_modules/@t3-oss/env-nextjs"],
+            "message": "Importing from '@t3-oss/env-nextjs' is restricted except in lib/env/env.ts."
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
import/no-restricted-pathsルールで@t3-oss/env-nextjsを特定のパスのファイルからでしかimportできないようにする