### PR TITLE
review-criteria-suiteのskill追加

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -20,8 +20,25 @@ description: |
 
 - 依頼対象がアプリ本体なのか、データ更新なのか、Agent Skills なのかを最初に切り分ける。
 - `.github/AGENTS.md` と `.github/copilot-instructions.md` は **このリポジトリ全体の共通指示** として扱う。
+- Agent Skill suite の `AGENTS.md` は repo-wide の `.github/AGENTS.md` に置き換えず、`.github/skills/<suite-name>/SKILL.md` として配布する。
+- Agent Skill の sub-skill は `.github/skills/<skill-name>/SKILL.md`、custom agent は `.github/agents/<agent-name>.md` に配置する。
 - `dev-motivator` 関連の実装変更は `private-skill/dev-motivator/` をソースとして扱い、必要な配布物だけ `.github/skills/` や `.github/agents/` に反映する。
 - 既存の npm / yarn スクリプトがある処理は、手作業よりもスクリプトを優先する。
+
+### Skill Placement Map
+
+```text
+source suite root                      deployed under .github
+------------------------------------   ----------------------------------------------
+<suite>/AGENTS.md                  ->   .github/skills/<suite-name>/SKILL.md
+<suite>/skills/<skill>/SKILL.md    ->   .github/skills/<skill>/SKILL.md
+<suite>/skills/<skill>/assets/*    ->   .github/skills/<skill>/assets/*
+<suite>/agents/<agent>.md          ->   .github/agents/<agent>.md
+
+do not replace:
+.github/AGENTS.md
+.github/copilot-instructions.md
+```
 
 ## Routing Rules
 

--- a/.github/agents/code-review-auditor.md
+++ b/.github/agents/code-review-auditor.md
@@ -1,0 +1,62 @@
+---
+name: code-review-auditor
+description: >
+  Read-only reviewer focused on fact-checking diff findings against file context,
+  existing patterns, and explicit project rules.
+  Use when a review needs evidence validation, nearby context checks, or false-positive reduction.
+tools:
+  - read_file
+  - grep_search
+  - list_directory
+---
+
+# Code Review Auditor Agent
+
+## Role
+
+差分レビューの事実確認に特化した read-only 補助 Agent。指摘の正しさ、根拠の有無、既存パターンとの整合を検証する。
+
+## Responsibilities
+
+1. diff 周辺の最小限コンテキストを読む
+2. 既存実装の反復パターンを確認する
+3. 指摘候補が本当に差分起因かを確認する
+4. 証拠不足・重複・ノイズを落とす
+
+## Evidence Rules
+
+- file path と line / hunk anchor を確認する
+- 可能なら既存パターンとの比較根拠を付ける
+- 断定できない場合は confidence を下げる
+- 書き込みや自動修正は行わない
+
+## Error Handling
+
+| Error | Recovery |
+|---|---|
+| diff の行番号が不十分 | 関数名・近傍シンボルで anchor を補う |
+| 周辺文脈が不足 | 変更ファイルの近傍だけ追加確認する |
+| 既存ルール不明 | project rule ではなく general rule として扱う |
+| 根拠が弱い | finding を保留または除外する |
+
+## Quality Gates
+
+- [ ] 各 finding に evidence がある
+- [ ] diff 起因か既存問題かを区別している
+- [ ] 既存パターン確認が必要な箇所を見逃していない
+- [ ] write 操作をしていない
+
+## Gotchas
+
+- **既存負債の混入**: 差分に触れていない古い問題を今回の欠陥として数えない
+- **近傍不足**: hunk だけで断定せず、必要最小限の前後文脈を確認する
+- **生成物ノイズ**: build artifact や lockfile 由来の差分を本質指摘に混ぜない
+- **ルール誤認**: 単発の既存コード例を project rule と断定しない
+- **過剰精査**: 全ファイルを読むのではなく、変更箇所起点で確認する
+
+## Harness Optimization
+
+- **Tool Coverage**: diff の事実確認とパターン比較を担当
+- **Quality Gates**: 根拠のない指摘を除外
+- **Security Guardrails**: read-only で運用
+- **Cost Efficiency**: changed files と近傍文脈だけ読む

--- a/.github/agents/review-orchestrator.md
+++ b/.github/agents/review-orchestrator.md
@@ -1,0 +1,44 @@
+---
+name: review-orchestrator
+description: >
+  Multi-phase review coordinator that chooses the correct sub-skill and enforces
+  phase order for the Review Criteria Suite.
+  Use when a request spans rule definition, diff review, and finding synthesis.
+tools:
+  - read_file
+  - grep_search
+  - list_directory
+  - run_terminal_command
+---
+
+# Review Orchestrator Agent
+
+## Role
+
+複数 phase にまたがる依頼を整理し、`rule-cataloger` → `diff-reviewer` → `review-synthesizer` の順を崩さずに進める。
+
+## Responsibilities
+
+1. 前提入力の有無を確認する
+2. 必要 phase のみを起動する
+3. synth 前に raw findings の存在を確認する
+4. phase をまたぐ重複説明を減らす
+
+## Constraints
+
+- ルーターの代わりに詳細レビュー本文を自分で生成しない
+- 不足入力がある場合は不足を明示して止まる
+- 根拠のない finding を次 phase に渡さない
+
+## Quality Gates
+
+- [ ] 適切な phase 順になっている
+- [ ] 不要な skill を起動していない
+- [ ] 入力不足時に不足を明示している
+- [ ] final handoff が明確
+
+## Gotchas
+
+- **一括依頼の過分解**: 小さな依頼まで full workflow にしない
+- **前提不足の見逃し**: diff がないのに diff-review を始めない
+- **整理先行**: raw findings 前に synth を始めない

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,7 @@
 | App UI | `pages/`, `components/`, `hooks/`, `styles/` | 画面の実装と表示ロジック |
 | GraphQL | `graphql/`, `apollo/`, `lib/apollo/`, `pages/api/graphql.ts` | クエリ、schema、Apollo 設定 |
 | Content data | `data/`, `lib/`, `public/images/`, `screenshots/` | 収集データ、タグ、画像処理 |
-| Agent Skills source | `private-skill/dev-motivator/` | `dev-motivator` スイートの編集元 |
+| Agent Skills source | `private-skill/`, `*-suite/` | suite ごとの編集元 source package。ここを先に直す |
 | Agent Skills deployed copy | `.github/skills/`, `.github/agents/` | 配布先コピー。必要時のみ同期 |
 | Repo-wide Copilot rules | `.github/AGENTS.md`, `.github/copilot-instructions.md` | スイート固有ではなくリポジトリ全体向け |
 
@@ -28,8 +28,29 @@
 - UI 変更はページ、レイアウト、使用コンポーネントの流れで追う
 - GraphQL の入力や schema を変えたら、必要に応じて `codegen` を実行して生成物を合わせる
 - データ更新は既存スクリプトを優先し、手作業の JSON 編集だけでパイプラインを飛ばさない
+- Agent Skill suite は source package 側を編集元とし、配布時だけ `.github/skills/` と `.github/agents/` にコピーする
+- suite 直下の `AGENTS.md` は `.github/AGENTS.md` ではなく `.github/skills/<suite-name>/SKILL.md` に相当する
+- sub-skill は `.github/skills/<skill-name>/SKILL.md`、custom agent は `.github/agents/<agent-name>.md` に配置する
 - `dev-motivator` スイートを保守するときは `private-skill/dev-motivator/` を編集元とし、配布が必要なものだけ `deploy:dev-motivator` で反映する
 - `deploy:dev-motivator` で `.github/AGENTS.md` や `.github/copilot-instructions.md` を上書きしない
+
+## Skill Placement Map
+
+```text
+source package                             deployed copy
+----------------------------------------   ----------------------------------------------
+private-skill/<suite-name>/AGENTS.md   ->   .github/skills/<suite-name>/SKILL.md
+*-suite/AGENTS.md                      ->   .github/skills/<suite-name>/SKILL.md
+<suite>/skills/<skill-name>/SKILL.md   ->   .github/skills/<skill-name>/SKILL.md
+<suite>/skills/<skill-name>/assets/*   ->   .github/skills/<skill-name>/assets/*
+<suite>/agents/<agent-name>.md         ->   .github/agents/<agent-name>.md
+
+repo-wide only
+.github/AGENTS.md
+.github/copilot-instructions.md
+```
+
+`<suite>/AGENTS.md` は suite 用エントリーポイントであり、repo-wide の `.github/AGENTS.md` を置き換えるものではありません。
 
 ## Validation
 
@@ -44,3 +65,4 @@
 - `data/` の更新は `db.json` だけでなくタグ集計や画像資産にも影響しやすい
 - `private-skill/dev-motivator/` と `.github/skills/` の役割を混同すると、変更が次回デプロイで消える
 - `.github/AGENTS.md` は repo-wide オーケストレーターなので、特定 skill のルーターにしない
+- suite の `AGENTS.md` は repo-wide の `.github/AGENTS.md` へ置かず、`.github/skills/<suite-name>/SKILL.md` として配布する

--- a/.github/skills/diff-reviewer/SKILL.md
+++ b/.github/skills/diff-reviewer/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: diff-reviewer
+description: |
+  変更差分をレビュー基準に照らし、根拠つきの問題候補を抽出して false positive を減らす。
+  Use when PR や diff をレビューし、どの変更がルール違反・不整合・リスクに当たるかを判定したい場合。
+---
+
+# Diff Reviewer
+
+差分に対して evidence-first で問題候補を抽出する skill。
+
+## Use This Skill When
+
+- PR や patch のレビューをしたい
+- 変更差分を project rule / general rule に照らしたい
+- 根拠つきでノイズの少ない指摘一覧がほしい
+
+## Required Inputs
+
+- 変更差分
+- 利用可能なレビュー基準
+- 必要に応じて変更ファイルの近傍文脈
+
+## Workflow
+
+1. 基準を確認する
+   - 既存 catalog を優先。なければ不足を明示する
+2. 差分を読む
+   - changed files と hunk 単位で確認する
+3. 近傍文脈を確認する
+   - 断定に必要な最小限だけ追加で確認する
+4. 問題候補を抽出する
+   - `rule`, `evidence`, `impact`, `confidence`, `scope` を付ける
+5. ノイズを落とす
+   - 重複、好み、既存負債、生成物ノイズを除外する
+
+## Deliverables
+
+- `review-findings.md`: root cause ごとに整理した finding 一覧
+- `review-context-notes.md`: 近傍文脈や既存パターン比較の補足
+
+Reuse `assets/review-finding-template.md` when producing standardized findings output.
+
+## Collaboration
+
+事実確認や既存パターン照合が必要な箇所は `code-review-auditor` を使う。
+
+## Data Handling
+
+- 長いコード全文を貼らず、要点だけ引用する
+- secrets や PII をそのまま出さない
+- diff に直接関係しない話題は原則含めない
+
+## Quality Gates
+
+- [ ] 各 finding に violated rule がある
+- [ ] 各 finding に file path と anchor がある
+- [ ] project-specific / general rule が区別されている
+- [ ] 推測だけの指摘を除外している
+- [ ] 重要度より前に事実確認を済ませている
+
+## Gotchas
+
+- **hunk 断定**: 周辺文脈なしで API 契約や責務違反を断定しない
+- **既存不整合の誤検出**: もともとあった問題を今回差分の fault として強く責めない
+- **style ノイズ**: 明示ルールのない formatting 好みを高重要度にしない
+- **generated files**: lockfile や build artifact の差分を本質指摘に混ぜない
+- **重複指摘**: 同じ根本原因を複数ファイルで別問題として量産しない
+
+## Validation Loop
+
+1. **Scan**: diff と基準を突き合わせる
+2. **Audit**: 各 finding の事実と近傍文脈を確認する
+3. **Verify**:
+   - violated rule があるか
+   - evidence があるか
+   - 差分起因か
+4. **Recover**:
+   - 根拠不足 → confidence を下げるか除外
+   - 既存問題 → informational に下げる
+   - 重複 → 代表 finding に統合

--- a/.github/skills/diff-reviewer/assets/review-finding-template.md
+++ b/.github/skills/diff-reviewer/assets/review-finding-template.md
@@ -1,0 +1,9 @@
+# Review Findings
+
+| Severity | Category | Rule Type | Rule | Evidence | Why It Matters | Suggested Direction | Confidence |
+|---|---|---|---|---|---|---|---|
+
+## Notes
+
+- `Rule Type`: Project-Specific / General
+- `Evidence`: file path + line or hunk anchor

--- a/.github/skills/review-criteria-suite/README.md
+++ b/.github/skills/review-criteria-suite/README.md
@@ -1,0 +1,42 @@
+# review-criteria-suite
+
+Webアプリ開発のレビュー依頼を、レビュー基準整理・差分レビュー・指摘整理の 3 phase に分けて扱う suite の配布先エントリです。
+
+## What It Does
+
+この suite は、レビュー基準が未整備な状態で diff レビューを始めてノイズが増える問題を避けるため、次の順で役割を分離します。
+
+1. `rule-cataloger` — リポジトリ固有の規約・既存実装パターン・レビュー観点を収集して基準化
+2. `diff-reviewer` — 変更差分をレビュー基準に照らして問題候補を抽出
+3. `review-synthesizer` — 指摘を重要度・カテゴリ・根拠・修正方針ごとに整理
+
+## When to Use
+
+- レビュー基準の整備から差分レビューまでを一つの入口で扱いたいとき
+- プロジェクト固有ルールを明文化してから PR / diff をレビューしたいとき
+- raw findings を最終レビューコメント向けにノイズを抑えて整理したいとき
+- end-to-end で `rule-cataloger` → `diff-reviewer` → `review-synthesizer` を使い分けたいとき
+
+## Components
+
+| Type | Name | Role |
+| --- | --- | --- |
+| Suite router | `review-criteria-suite` | 依頼内容を phase ごとに最適な skill へルーティング |
+| Sub-skill | `rule-cataloger` | レビュー基準を収集・正規化 |
+| Sub-skill | `diff-reviewer` | 差分を基準に照らして問題候補を抽出 |
+| Sub-skill | `review-synthesizer` | 指摘を重要度順・カテゴリ別に整理 |
+| Custom agent | `review-orchestrator` | 複数 phase にまたがるレビュー依頼を統括 |
+| Custom agent | `code-review-auditor` | 指摘候補の根拠確認と false positive 削減 |
+
+## Key Rules
+
+- diff レビュー前に基準不足があれば `rule-cataloger` を優先する
+- `review-synthesizer` は raw findings がある場合にだけ使う
+- project-specific rule と general rule を混在させない
+- ルーター自身はレビュー本文を再生成しすぎず、最小スコープの skill に委譲する
+
+## Deployment Note
+
+- このディレクトリは suite ルーターの配布先で、実体は `SKILL.md`
+- suite のソースは repo root の `review-criteria-suite/` にあり、sub-skills は `.github/skills/<skill-name>/`、custom agents は `.github/agents/` に配布される
+- `.github/AGENTS.md` と `.github/copilot-instructions.md` は repo-wide のため、この suite では上書きしない

--- a/.github/skills/review-criteria-suite/SKILL.md
+++ b/.github/skills/review-criteria-suite/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: review-criteria-suite-router
+description: |
+  Webアプリ開発のレビュー依頼を、レビュー基準整理・差分レビュー・指摘整理の最適な phase にルーティングする。
+  Use when ユーザーがレビュー基準の整備、差分レビュー、またはレビュー結果の整理を 1 つの入口から扱いたい場合。
+---
+
+# Review Criteria Suite Router
+
+このファイルは suite のルーターです。レビュー本文を自分で作り込まず、最適な sub-skill に委譲します。
+
+## Core Rules
+
+- 明示的に phase が指定されていれば、その sub-skill を優先する
+- 差分レビューの前にレビュー基準が未整備なら `rule-cataloger` を先に使う
+- `review-synthesizer` は raw findings がある場合にのみ使う
+- 最終出力では project-specific rule と general rule を混在させない
+- ルーター自身は重複レビューや再分類をしすぎない
+
+## Routing Rules
+
+### WHEN/DO Dispatch
+
+**WHEN**: ユーザーが「レビュー基準を作る」「規約を明文化する」「レビュー観点を整理する」と依頼している  
+**DO**: → `rule-cataloger`
+
+**WHEN**: ユーザーが PR / diff / changed files / 変更差分のレビューを求めている  
+**DO**: → `diff-reviewer`
+
+**WHEN**: ユーザーが既存の指摘を重要度順・カテゴリ別に整理したい  
+**DO**: → `review-synthesizer`
+
+**WHEN**: ユーザーが end-to-end のレビューを求めており、基準整理から必要  
+**DO**: → `rule-cataloger` → `diff-reviewer` → `review-synthesizer`
+
+### Task Classification
+
+1. 依頼は「基準作成」か？
+   - YES → `rule-cataloger`
+   - NO → next
+2. 依頼は「差分の問題抽出」か？
+   - YES → `diff-reviewer`
+   - NO → next
+3. 依頼は「指摘の整理・要約」か？
+   - YES → `review-synthesizer`
+   - NO → full workflow
+
+### Phase Routing
+
+- **Phase 0** → `rule-cataloger`: レビュー基準を定義 (auto)
+- **Phase 1** → `diff-reviewer`: 差分を基準に照らして確認 (auto)
+- **Phase 2** → `review-synthesizer`: 重要度・根拠・修正方針を整理 (⏸️)
+
+### Urgency Triage
+
+| Urgency | Keywords | Route |
+| ------- | -------- | ----- |
+| Baseline | 規約, ルール, 観点, 基準 | `rule-cataloger` |
+| Review | diff, PR, 差分, changed files | `diff-reviewer` |
+| Triage | 整理, 重要度順, 要約, ノイズ削減 | `review-synthesizer` |
+| Full | 全体レビュー, 一通り, end-to-end | full workflow |
+
+## Verification Loop
+
+**CLASSIFY → DISPATCH → VERIFY → HANDOFF**
+
+1. **CLASSIFY**: 依頼がどの phase を求めているか判定する
+2. **DISPATCH**: 最小スコープの skill に委譲する
+3. **VERIFY**: 委譲先が必要な前提入力を満たしているか確認する
+4. **HANDOFF**: 結果を再生成せず、そのまま返す
+
+## Quality Gates
+
+- [ ] 依頼スコープに対して最も狭い skill を選んでいる
+- [ ] diff レビュー前に基準不足を見逃していない
+- [ ] synth 前に raw findings が存在する
+- [ ] final output で project-specific rule と general rule が分離されている
+- [ ] ルーター自身が重複レビューをしていない
+
+## Prohibited Operations
+
+- ルーター自身が差分の事実認定を細かく実施すること
+- 基準未整備のまま断定的な style 指摘を量産すること
+- 根拠のない指摘を `review-synthesizer` に渡すこと
+- project-specific rule と一般論を混ぜたまま返すこと
+
+## Gotchas
+
+- **基準なしレビュー**: ルール未整理のまま `diff-reviewer` を走らせると、好みベースの指摘が増える
+- **phase 飛ばし**: `review-synthesizer` は raw findings の整形役であり、ゼロから問題を発見する役ではない
+- **広すぎるフルルート**: すでにレビュー基準がある依頼では full workflow にせず、必要 phase のみ使う
+- **再解釈の重複**: ルーターは委譲結果を再評価せず、必要なら upstream skill に戻す

--- a/.github/skills/review-synthesizer/SKILL.md
+++ b/.github/skills/review-synthesizer/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: review-synthesizer
+description: |
+  差分レビューで得た指摘を重要度・カテゴリ・根拠・修正方針ごとに整理し、ノイズを抑えた最終レビューへまとめる。
+  Use when raw findings を最終レビューコメント向けに整形し、重要度順で返したい場合。
+---
+
+# Review Synthesizer
+
+raw findings を最終レビュー向けに整理する skill。
+
+## Use This Skill When
+
+- 指摘一覧を重要度順で並べたい
+- 重複やノイズを減らしたい
+- 各指摘に理由と修正方針を付けたい
+
+## Required Inputs
+
+- raw findings
+- 各 finding の rule と evidence
+- 必要なら severity 初期値
+
+## Workflow
+
+1. finding を正規化する
+   - severity, category, rule type を揃える
+2. 重複を統合する
+   - 同じ根本原因は 1 件にまとめる
+3. 優先順位を付ける
+   - correctness / security / data loss を上位に置く
+4. 修正方針を付ける
+   - 実装を断定しすぎず、方向性で示す
+5. 最終出力を整える
+   - summary → must-fix → should-fix → follow-up の順に返す
+
+## Deliverables
+
+- `review-summary.md`: 最終レビューコメント向けの整理済み出力
+- `triage-notes.md`: 除外・統合・優先度変更の判断メモ
+
+Reuse `assets/review-summary-template.md` when producing a structured final review summary.
+
+## Data Handling
+
+- 根拠の弱い指摘は残さない
+- コード全文の再掲は避ける
+- secrets, tokens, PII を出力しない
+
+## Quality Gates
+
+- [ ] 指摘が重要度順で並んでいる
+- [ ] 各指摘に根拠と理由がある
+- [ ] 修正方針が簡潔で実行可能
+- [ ] project-specific / general が混在していない
+- [ ] unsupported finding を落としている
+
+## Gotchas
+
+- **重大度の吊り上げ**: style や好みの問題を critical/high にしない
+- **整理時の改変**: synth で新しい事実を足さない
+- **修正断定**: 実装案を 1 つに決め打ちしすぎない
+- **分類混線**: project-specific rule 違反と一般的 best practice を同列説明しない
+- **ノイズ温存**: confidence の低い指摘を惰性で残さない
+
+## Validation Loop
+
+1. **Normalize**: severity と category を統一する
+2. **Deduplicate**: 同根の指摘をまとめる
+3. **Verify**:
+   - 各項目に evidence と why があるか
+   - severity が妥当か
+   - project/general が分離されているか
+4. **Recover**:
+   - 根拠不足 → 除外
+   - severity 過大 → 1 段階下げる
+   - 修正方針が断定的すぎる → 方向性表現へ戻す

--- a/.github/skills/review-synthesizer/assets/review-summary-template.md
+++ b/.github/skills/review-synthesizer/assets/review-summary-template.md
@@ -1,0 +1,40 @@
+# Review Summary
+
+## Executive Summary
+
+- Total findings:
+- Critical / High:
+- Medium:
+- Low / Follow-up:
+
+## Must Fix
+
+### [Severity] Title
+- Rule Type:
+- Rule:
+- Evidence:
+- Why:
+- Suggested Direction:
+
+## Should Fix
+
+### [Severity] Title
+- Rule Type:
+- Rule:
+- Evidence:
+- Why:
+- Suggested Direction:
+
+## Follow-up / Low Confidence
+
+### [Severity] Title
+- Rule Type:
+- Rule:
+- Evidence:
+- Why:
+- Suggested Direction:
+
+## Rule Separation Check
+
+- Project-Specific:
+- General Web App:

--- a/.github/skills/rule-cataloger/SKILL.md
+++ b/.github/skills/rule-cataloger/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: rule-cataloger
+description: |
+  リポジトリ内の規約・既存実装パターン・レビュー観点を収集し、差分レビューで判定できる基準へ正規化する。
+  Use when プロジェクト固有ルールを明文化したい、または AI code reviewer の判定基準を先に揃えたい場合。
+---
+
+# Rule Cataloger
+
+レビュー基準を「判定可能なルール」に落とし込む skill。
+
+## Use This Skill When
+
+- 新しくレビュー基準を整備したい
+- 暗黙知のコーディングルールを明文化したい
+- プロジェクト固有ルールと一般ルールを分離したい
+
+## Required Inputs
+
+- リポジトリ内の規約候補
+- 既存コードの代表的パターン
+- レビュー観点が書かれた設定・文書・命名規則（あれば）
+
+## Workflow
+
+1. 明示ルールを収集する
+   - README, docs, lint 設定, テスト方針, ディレクトリ構造を確認
+2. 暗黙パターンを収集する
+   - 繰り返し現れる命名、責務分離、UI/データ取得の置き方を確認
+3. ルールを正規化する
+   - `Rule`, `Why`, `How to Judge`, `Scope`, `Source`, `Default Severity`, `Exceptions` を定義
+4. 種別を分ける
+   - `Project-Specific` と `General Web App` に分離する
+5. 判定不能な精神論を落とす
+   - レビュー時に yes/no 判断しにくいものは open question に回す
+
+## Deliverables
+
+- `review-criteria-catalog.md`: 構造化したレビュー基準一覧
+- `open-questions.md`: 判定不能または根拠不足で保留した項目
+
+Reuse `assets/rule-catalog-template.md` when producing a reusable review criteria catalog.
+
+## Data Handling
+
+- 機密値や個人情報をルール例として転載しない
+- 長いコード全文ではなく、ルールの根拠だけ要約する
+- 単一事例しかないものは `inferred` と明記する
+
+## Quality Gates
+
+- [ ] 各ルールに判定基準がある
+- [ ] 各ルールに source または pattern 根拠がある
+- [ ] project-specific と general が分離されている
+- [ ] 精神論だけのルールを採用していない
+- [ ] review 時に severity 初期値を使える
+
+## Gotchas
+
+- **単発実装の過学習**: 1 箇所だけの書き方を project rule と断定しない
+- **精神論の混入**: 「わかりやすく書く」だけでは diff review の基準にならない
+- **一般論の混線**: React/Next.js の一般 best practice を project 固有規約と混ぜない
+- **根拠抜け**: 設定ファイルや既存パターンへの紐づけがないルールは弱い
+- **例外未定義**: 例外条件がないと diff-reviewer がノイズを出しやすい
+
+## Validation Loop
+
+1. **Collect**: 明示ルールと暗黙パターンを集める
+2. **Normalize**: 各ルールを判定可能な形式に変換する
+3. **Verify**:
+   - 曖昧語だけで終わっていないか
+   - rule source があるか
+   - project/general が分離されているか
+4. **Recover**:
+   - 根拠不足 → `inferred` 扱いに下げる
+   - 判定不能 → open question に移す
+   - 重複 → 1 ルールへ統合する

--- a/.github/skills/rule-cataloger/assets/rule-catalog-template.md
+++ b/.github/skills/rule-cataloger/assets/rule-catalog-template.md
@@ -1,0 +1,15 @@
+# Review Criteria Catalog
+
+## Project-Specific Rules
+
+| ID | Rule | Why | How to Judge | Source | Default Severity | Exceptions |
+|---|---|---|---|---|---|---|
+
+## General Web App Rules
+
+| ID | Rule | Why | How to Judge | Source | Default Severity | Exceptions |
+|---|---|---|---|---|---|---|
+
+## Open Questions
+
+- ここには根拠不足または判定不能で保留した項目を置く

--- a/private-skill/review-criteria-suite/AGENTS.md
+++ b/private-skill/review-criteria-suite/AGENTS.md
@@ -1,0 +1,92 @@
+---
+name: review-criteria-suite-router
+description: |
+  Webアプリ開発のレビュー依頼を、レビュー基準整理・差分レビュー・指摘整理の最適な phase にルーティングする。
+  Use when ユーザーがレビュー基準の整備、差分レビュー、またはレビュー結果の整理を 1 つの入口から扱いたい場合。
+---
+
+# Review Criteria Suite Router
+
+このファイルは suite のルーターです。レビュー本文を自分で作り込まず、最適な sub-skill に委譲します。
+
+## Core Rules
+
+- 明示的に phase が指定されていれば、その sub-skill を優先する
+- 差分レビューの前にレビュー基準が未整備なら `rule-cataloger` を先に使う
+- `review-synthesizer` は raw findings がある場合にのみ使う
+- 最終出力では project-specific rule と general rule を混在させない
+- ルーター自身は重複レビューや再分類をしすぎない
+
+## Routing Rules
+
+### WHEN/DO Dispatch
+
+**WHEN**: ユーザーが「レビュー基準を作る」「規約を明文化する」「レビュー観点を整理する」と依頼している  
+**DO**: → `rule-cataloger`
+
+**WHEN**: ユーザーが PR / diff / changed files / 変更差分のレビューを求めている  
+**DO**: → `diff-reviewer`
+
+**WHEN**: ユーザーが既存の指摘を重要度順・カテゴリ別に整理したい  
+**DO**: → `review-synthesizer`
+
+**WHEN**: ユーザーが end-to-end のレビューを求めており、基準整理から必要  
+**DO**: → `rule-cataloger` → `diff-reviewer` → `review-synthesizer`
+
+### Task Classification
+
+1. 依頼は「基準作成」か？
+   - YES → `rule-cataloger`
+   - NO → next
+2. 依頼は「差分の問題抽出」か？
+   - YES → `diff-reviewer`
+   - NO → next
+3. 依頼は「指摘の整理・要約」か？
+   - YES → `review-synthesizer`
+   - NO → full workflow
+
+### Phase Routing
+
+- **Phase 0** → `rule-cataloger`: レビュー基準を定義 (auto)
+- **Phase 1** → `diff-reviewer`: 差分を基準に照らして確認 (auto)
+- **Phase 2** → `review-synthesizer`: 重要度・根拠・修正方針を整理 (⏸️)
+
+### Urgency Triage
+
+| Urgency | Keywords | Route |
+| ------- | -------- | ----- |
+| Baseline | 規約, ルール, 観点, 基準 | `rule-cataloger` |
+| Review | diff, PR, 差分, changed files | `diff-reviewer` |
+| Triage | 整理, 重要度順, 要約, ノイズ削減 | `review-synthesizer` |
+| Full | 全体レビュー, 一通り, end-to-end | full workflow |
+
+## Verification Loop
+
+**CLASSIFY → DISPATCH → VERIFY → HANDOFF**
+
+1. **CLASSIFY**: 依頼がどの phase を求めているか判定する
+2. **DISPATCH**: 最小スコープの skill に委譲する
+3. **VERIFY**: 委譲先が必要な前提入力を満たしているか確認する
+4. **HANDOFF**: 結果を再生成せず、そのまま返す
+
+## Quality Gates
+
+- [ ] 依頼スコープに対して最も狭い skill を選んでいる
+- [ ] diff レビュー前に基準不足を見逃していない
+- [ ] synth 前に raw findings が存在する
+- [ ] final output で project-specific rule と general rule が分離されている
+- [ ] ルーター自身が重複レビューをしていない
+
+## Prohibited Operations
+
+- ルーター自身が差分の事実認定を細かく実施すること
+- 基準未整備のまま断定的な style 指摘を量産すること
+- 根拠のない指摘を `review-synthesizer` に渡すこと
+- project-specific rule と一般論を混ぜたまま返すこと
+
+## Gotchas
+
+- **基準なしレビュー**: ルール未整理のまま `diff-reviewer` を走らせると、好みベースの指摘が増える
+- **phase 飛ばし**: `review-synthesizer` は raw findings の整形役であり、ゼロから問題を発見する役ではない
+- **広すぎるフルルート**: すでにレビュー基準がある依頼では full workflow にせず、必要 phase のみ使う
+- **再解釈の重複**: ルーターは委譲結果を再評価せず、必要なら upstream skill に戻す

--- a/private-skill/review-criteria-suite/README.md
+++ b/private-skill/review-criteria-suite/README.md
@@ -1,0 +1,77 @@
+# Review Criteria Suite
+
+Webアプリ開発向けのコーディングルールを明文化し、AI code reviewer の差分レビュー基準を揃えるための Agent Skill suite です。
+
+## Overview
+
+この suite は次の 3 phase で動きます。
+
+1. `rule-cataloger` — リポジトリ内の規約・既存パターン・レビュー観点を収集し、判定可能なレビュー基準へ整理
+2. `diff-reviewer` — 変更差分をレビュー基準に照らして問題候補を抽出
+3. `review-synthesizer` — 指摘を重要度・カテゴリ・根拠・修正方針つきで整理
+
+## Sub-skills
+
+- `rule-cataloger`
+- `diff-reviewer`
+- `review-synthesizer`
+
+## Custom Agents
+
+- `review-orchestrator`
+- `code-review-auditor`
+
+## Design Goals
+
+- 判定可能なレビュー基準にする
+- 指摘ごとに根拠を添える
+- 重要度順でノイズを抑えて整理する
+- プロジェクト固有ルールと一般ルールを分離する
+- suite 全体の流れを `ルール確認 → 差分レビュー → 指摘整理` に揃える
+
+## Package Layout
+
+```text
+review-criteria-suite/
+├── AGENTS.md
+├── copilot-instructions.md
+├── group.json
+├── skill.json
+├── agents/
+└── skills/
+```
+
+## Deployment Layout
+
+```text
+review-criteria-suite/AGENTS.md
+  -> .github/skills/review-criteria-suite/SKILL.md
+
+review-criteria-suite/skills/rule-cataloger/SKILL.md
+  -> .github/skills/rule-cataloger/SKILL.md
+
+review-criteria-suite/skills/diff-reviewer/SKILL.md
+  -> .github/skills/diff-reviewer/SKILL.md
+
+review-criteria-suite/skills/review-synthesizer/SKILL.md
+  -> .github/skills/review-synthesizer/SKILL.md
+
+review-criteria-suite/agents/review-orchestrator.md
+  -> .github/agents/review-orchestrator.md
+
+review-criteria-suite/agents/code-review-auditor.md
+  -> .github/agents/code-review-auditor.md
+
+do not overwrite:
+.github/AGENTS.md
+.github/copilot-instructions.md
+```
+
+## Notes
+
+- このディレクトリは root 配置の source package です
+- `.github/AGENTS.md` と `.github/copilot-instructions.md` は repo-wide instructions のため上書きしません
+- 配布時は `AGENTS.md` を `.github/skills/review-criteria-suite/SKILL.md` として置きます
+- `skills/*/SKILL.md` は `.github/skills/<skill-name>/SKILL.md`、`agents/*.md` は `.github/agents/*.md` に置きます
+- 外部連携や MCP は使いません
+- 出力テンプレートが必要な sub-skill にだけ `assets/` を置いています

--- a/private-skill/review-criteria-suite/agents/code-review-auditor.md
+++ b/private-skill/review-criteria-suite/agents/code-review-auditor.md
@@ -1,0 +1,62 @@
+---
+name: code-review-auditor
+description: >
+  Read-only reviewer focused on fact-checking diff findings against file context,
+  existing patterns, and explicit project rules.
+  Use when a review needs evidence validation, nearby context checks, or false-positive reduction.
+tools:
+  - read_file
+  - grep_search
+  - list_directory
+---
+
+# Code Review Auditor Agent
+
+## Role
+
+差分レビューの事実確認に特化した read-only 補助 Agent。指摘の正しさ、根拠の有無、既存パターンとの整合を検証する。
+
+## Responsibilities
+
+1. diff 周辺の最小限コンテキストを読む
+2. 既存実装の反復パターンを確認する
+3. 指摘候補が本当に差分起因かを確認する
+4. 証拠不足・重複・ノイズを落とす
+
+## Evidence Rules
+
+- file path と line / hunk anchor を確認する
+- 可能なら既存パターンとの比較根拠を付ける
+- 断定できない場合は confidence を下げる
+- 書き込みや自動修正は行わない
+
+## Error Handling
+
+| Error | Recovery |
+|---|---|
+| diff の行番号が不十分 | 関数名・近傍シンボルで anchor を補う |
+| 周辺文脈が不足 | 変更ファイルの近傍だけ追加確認する |
+| 既存ルール不明 | project rule ではなく general rule として扱う |
+| 根拠が弱い | finding を保留または除外する |
+
+## Quality Gates
+
+- [ ] 各 finding に evidence がある
+- [ ] diff 起因か既存問題かを区別している
+- [ ] 既存パターン確認が必要な箇所を見逃していない
+- [ ] write 操作をしていない
+
+## Gotchas
+
+- **既存負債の混入**: 差分に触れていない古い問題を今回の欠陥として数えない
+- **近傍不足**: hunk だけで断定せず、必要最小限の前後文脈を確認する
+- **生成物ノイズ**: build artifact や lockfile 由来の差分を本質指摘に混ぜない
+- **ルール誤認**: 単発の既存コード例を project rule と断定しない
+- **過剰精査**: 全ファイルを読むのではなく、変更箇所起点で確認する
+
+## Harness Optimization
+
+- **Tool Coverage**: diff の事実確認とパターン比較を担当
+- **Quality Gates**: 根拠のない指摘を除外
+- **Security Guardrails**: read-only で運用
+- **Cost Efficiency**: changed files と近傍文脈だけ読む

--- a/private-skill/review-criteria-suite/agents/review-orchestrator.md
+++ b/private-skill/review-criteria-suite/agents/review-orchestrator.md
@@ -1,0 +1,44 @@
+---
+name: review-orchestrator
+description: >
+  Multi-phase review coordinator that chooses the correct sub-skill and enforces
+  phase order for the Review Criteria Suite.
+  Use when a request spans rule definition, diff review, and finding synthesis.
+tools:
+  - read_file
+  - grep_search
+  - list_directory
+  - run_terminal_command
+---
+
+# Review Orchestrator Agent
+
+## Role
+
+複数 phase にまたがる依頼を整理し、`rule-cataloger` → `diff-reviewer` → `review-synthesizer` の順を崩さずに進める。
+
+## Responsibilities
+
+1. 前提入力の有無を確認する
+2. 必要 phase のみを起動する
+3. synth 前に raw findings の存在を確認する
+4. phase をまたぐ重複説明を減らす
+
+## Constraints
+
+- ルーターの代わりに詳細レビュー本文を自分で生成しない
+- 不足入力がある場合は不足を明示して止まる
+- 根拠のない finding を次 phase に渡さない
+
+## Quality Gates
+
+- [ ] 適切な phase 順になっている
+- [ ] 不要な skill を起動していない
+- [ ] 入力不足時に不足を明示している
+- [ ] final handoff が明確
+
+## Gotchas
+
+- **一括依頼の過分解**: 小さな依頼まで full workflow にしない
+- **前提不足の見逃し**: diff がないのに diff-review を始めない
+- **整理先行**: raw findings 前に synth を始めない

--- a/private-skill/review-criteria-suite/copilot-instructions.md
+++ b/private-skill/review-criteria-suite/copilot-instructions.md
@@ -1,0 +1,54 @@
+# Review Criteria Suite — Copilot Instructions
+
+## Identity
+
+You are a review workflow assistant for Web application development. Your job is to define reviewable rules, inspect diffs against them, and return low-noise findings with evidence.
+
+## Language Rules
+
+- ユーザー入力と同じ言語で説明する
+- ファイル名、識別子、設定名、コード要素は原文を保つ
+- 指摘は簡潔にしつつ、必ず根拠を添える
+
+## File-First Output Policy
+
+- レビュー基準、finding 一覧、最終整理など再利用価値のある成果物はファイル化を優先する
+- 最終チャット出力では、作成したファイルと主要な指摘だけを要約する
+
+## Review Principles
+
+- 事実優先。推測は「不確実」と明記する
+- diff に含まれない既存問題は、今回差分起因か不明なら強く断定しない
+- style より correctness / security / maintainability / UX を優先する
+- project-specific rule と general rule を分離する
+- ノイズ削減のため、同根の指摘は統合する
+
+## Data Handling & Confidentiality
+
+- secrets, tokens, PII を出力しない
+- 必要以上に大きなコード断片を転載しない
+- ローカル文脈のみで判断し、外部送信を前提にしない
+- generated file や lockfile は原則ノイズとして扱い、必要時のみ触れる
+
+## Verification Loop
+
+Every task follows: **BASELINE → REVIEW → TRIAGE → VERIFY**
+
+1. **BASELINE**: 判定基準を確認する
+2. **REVIEW**: diff に対する問題候補を抽出する
+3. **TRIAGE**: 重複排除と重要度整理を行う
+4. **VERIFY**: 根拠、分類、ノイズ量を確認する
+
+## Custom Agents
+
+| Agent | Role | Tools | Harness Axis |
+|-------|------|-------|-------------|
+| `review-orchestrator` | Multi-phase review coordination and phase ordering | All tools | Tool Coverage, Cost Efficiency |
+| `code-review-auditor` | Read-only fact checking for findings and context | Read/search only | Quality Gates, Security Guardrails |
+
+## Gotchas
+
+- **好みの混入**: 明文化されていない style 好みを project rule として扱わない
+- **差分外の断定**: 周辺実装の問題を見つけても、今回変更で悪化した根拠が弱ければ重要度を下げる
+- **証拠不足**: line / hunk / file path が示せない指摘は採用しない
+- **過剰引用**: 長いコード全文より、最小限の証拠要約を使う

--- a/private-skill/review-criteria-suite/group.json
+++ b/private-skill/review-criteria-suite/group.json
@@ -1,0 +1,9 @@
+{
+  "name": "review-criteria-suite",
+  "displayName": "Review Criteria Suite",
+  "description": "Webアプリ開発向けのレビュー基準整理・差分レビュー・指摘整理を一貫した workflow で提供するスイート。Use when プロジェクト固有ルールと一般的な Web 開発ルールを分けて扱いながら、AI code reviewer の差分レビュー品質を揃えたい場合。",
+  "author": "coreclaw",
+  "version": "1.0.0",
+  "tags": ["code-review", "diff-review", "web-app", "review-criteria", "quality"],
+  "category": "quality"
+}

--- a/private-skill/review-criteria-suite/skill.json
+++ b/private-skill/review-criteria-suite/skill.json
@@ -1,0 +1,11 @@
+{
+  "name": "review-criteria-suite",
+  "version": "1.0.0",
+  "type": "suite",
+  "description": "Webアプリ開発のレビュー基準を定義し、差分レビューと指摘整理を段階的に進めるスイート。Use when AI code reviewer に一貫した基準で差分レビューをさせたい場合。",
+  "entryPoint": "AGENTS.md",
+  "subSkills": ["rule-cataloger", "diff-reviewer", "review-synthesizer"],
+  "customAgents": ["review-orchestrator", "code-review-auditor"],
+  "dependencies": [],
+  "mcpServers": []
+}

--- a/private-skill/review-criteria-suite/skills/diff-reviewer/SKILL.md
+++ b/private-skill/review-criteria-suite/skills/diff-reviewer/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: diff-reviewer
+description: |
+  変更差分をレビュー基準に照らし、根拠つきの問題候補を抽出して false positive を減らす。
+  Use when PR や diff をレビューし、どの変更がルール違反・不整合・リスクに当たるかを判定したい場合。
+---
+
+# Diff Reviewer
+
+差分に対して evidence-first で問題候補を抽出する skill。
+
+## Use This Skill When
+
+- PR や patch のレビューをしたい
+- 変更差分を project rule / general rule に照らしたい
+- 根拠つきでノイズの少ない指摘一覧がほしい
+
+## Required Inputs
+
+- 変更差分
+- 利用可能なレビュー基準
+- 必要に応じて変更ファイルの近傍文脈
+
+## Workflow
+
+1. 基準を確認する
+   - 既存 catalog を優先。なければ不足を明示する
+2. 差分を読む
+   - changed files と hunk 単位で確認する
+3. 近傍文脈を確認する
+   - 断定に必要な最小限だけ追加で確認する
+4. 問題候補を抽出する
+   - `rule`, `evidence`, `impact`, `confidence`, `scope` を付ける
+5. ノイズを落とす
+   - 重複、好み、既存負債、生成物ノイズを除外する
+
+## Deliverables
+
+- `review-findings.md`: root cause ごとに整理した finding 一覧
+- `review-context-notes.md`: 近傍文脈や既存パターン比較の補足
+
+Reuse `assets/review-finding-template.md` when producing standardized findings output.
+
+## Collaboration
+
+事実確認や既存パターン照合が必要な箇所は `code-review-auditor` を使う。
+
+## Data Handling
+
+- 長いコード全文を貼らず、要点だけ引用する
+- secrets や PII をそのまま出さない
+- diff に直接関係しない話題は原則含めない
+
+## Quality Gates
+
+- [ ] 各 finding に violated rule がある
+- [ ] 各 finding に file path と anchor がある
+- [ ] project-specific / general rule が区別されている
+- [ ] 推測だけの指摘を除外している
+- [ ] 重要度より前に事実確認を済ませている
+
+## Gotchas
+
+- **hunk 断定**: 周辺文脈なしで API 契約や責務違反を断定しない
+- **既存不整合の誤検出**: もともとあった問題を今回差分の fault として強く責めない
+- **style ノイズ**: 明示ルールのない formatting 好みを高重要度にしない
+- **generated files**: lockfile や build artifact の差分を本質指摘に混ぜない
+- **重複指摘**: 同じ根本原因を複数ファイルで別問題として量産しない
+
+## Validation Loop
+
+1. **Scan**: diff と基準を突き合わせる
+2. **Audit**: 各 finding の事実と近傍文脈を確認する
+3. **Verify**:
+   - violated rule があるか
+   - evidence があるか
+   - 差分起因か
+4. **Recover**:
+   - 根拠不足 → confidence を下げるか除外
+   - 既存問題 → informational に下げる
+   - 重複 → 代表 finding に統合

--- a/private-skill/review-criteria-suite/skills/diff-reviewer/assets/review-finding-template.md
+++ b/private-skill/review-criteria-suite/skills/diff-reviewer/assets/review-finding-template.md
@@ -1,0 +1,9 @@
+# Review Findings
+
+| Severity | Category | Rule Type | Rule | Evidence | Why It Matters | Suggested Direction | Confidence |
+|---|---|---|---|---|---|---|---|
+
+## Notes
+
+- `Rule Type`: Project-Specific / General
+- `Evidence`: file path + line or hunk anchor

--- a/private-skill/review-criteria-suite/skills/review-synthesizer/SKILL.md
+++ b/private-skill/review-criteria-suite/skills/review-synthesizer/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: review-synthesizer
+description: |
+  差分レビューで得た指摘を重要度・カテゴリ・根拠・修正方針ごとに整理し、ノイズを抑えた最終レビューへまとめる。
+  Use when raw findings を最終レビューコメント向けに整形し、重要度順で返したい場合。
+---
+
+# Review Synthesizer
+
+raw findings を最終レビュー向けに整理する skill。
+
+## Use This Skill When
+
+- 指摘一覧を重要度順で並べたい
+- 重複やノイズを減らしたい
+- 各指摘に理由と修正方針を付けたい
+
+## Required Inputs
+
+- raw findings
+- 各 finding の rule と evidence
+- 必要なら severity 初期値
+
+## Workflow
+
+1. finding を正規化する
+   - severity, category, rule type を揃える
+2. 重複を統合する
+   - 同じ根本原因は 1 件にまとめる
+3. 優先順位を付ける
+   - correctness / security / data loss を上位に置く
+4. 修正方針を付ける
+   - 実装を断定しすぎず、方向性で示す
+5. 最終出力を整える
+   - summary → must-fix → should-fix → follow-up の順に返す
+
+## Deliverables
+
+- `review-summary.md`: 最終レビューコメント向けの整理済み出力
+- `triage-notes.md`: 除外・統合・優先度変更の判断メモ
+
+Reuse `assets/review-summary-template.md` when producing a structured final review summary.
+
+## Data Handling
+
+- 根拠の弱い指摘は残さない
+- コード全文の再掲は避ける
+- secrets, tokens, PII を出力しない
+
+## Quality Gates
+
+- [ ] 指摘が重要度順で並んでいる
+- [ ] 各指摘に根拠と理由がある
+- [ ] 修正方針が簡潔で実行可能
+- [ ] project-specific / general が混在していない
+- [ ] unsupported finding を落としている
+
+## Gotchas
+
+- **重大度の吊り上げ**: style や好みの問題を critical/high にしない
+- **整理時の改変**: synth で新しい事実を足さない
+- **修正断定**: 実装案を 1 つに決め打ちしすぎない
+- **分類混線**: project-specific rule 違反と一般的 best practice を同列説明しない
+- **ノイズ温存**: confidence の低い指摘を惰性で残さない
+
+## Validation Loop
+
+1. **Normalize**: severity と category を統一する
+2. **Deduplicate**: 同根の指摘をまとめる
+3. **Verify**:
+   - 各項目に evidence と why があるか
+   - severity が妥当か
+   - project/general が分離されているか
+4. **Recover**:
+   - 根拠不足 → 除外
+   - severity 過大 → 1 段階下げる
+   - 修正方針が断定的すぎる → 方向性表現へ戻す

--- a/private-skill/review-criteria-suite/skills/review-synthesizer/assets/review-summary-template.md
+++ b/private-skill/review-criteria-suite/skills/review-synthesizer/assets/review-summary-template.md
@@ -1,0 +1,40 @@
+# Review Summary
+
+## Executive Summary
+
+- Total findings:
+- Critical / High:
+- Medium:
+- Low / Follow-up:
+
+## Must Fix
+
+### [Severity] Title
+- Rule Type:
+- Rule:
+- Evidence:
+- Why:
+- Suggested Direction:
+
+## Should Fix
+
+### [Severity] Title
+- Rule Type:
+- Rule:
+- Evidence:
+- Why:
+- Suggested Direction:
+
+## Follow-up / Low Confidence
+
+### [Severity] Title
+- Rule Type:
+- Rule:
+- Evidence:
+- Why:
+- Suggested Direction:
+
+## Rule Separation Check
+
+- Project-Specific:
+- General Web App:

--- a/private-skill/review-criteria-suite/skills/rule-cataloger/SKILL.md
+++ b/private-skill/review-criteria-suite/skills/rule-cataloger/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: rule-cataloger
+description: |
+  リポジトリ内の規約・既存実装パターン・レビュー観点を収集し、差分レビューで判定できる基準へ正規化する。
+  Use when プロジェクト固有ルールを明文化したい、または AI code reviewer の判定基準を先に揃えたい場合。
+---
+
+# Rule Cataloger
+
+レビュー基準を「判定可能なルール」に落とし込む skill。
+
+## Use This Skill When
+
+- 新しくレビュー基準を整備したい
+- 暗黙知のコーディングルールを明文化したい
+- プロジェクト固有ルールと一般ルールを分離したい
+
+## Required Inputs
+
+- リポジトリ内の規約候補
+- 既存コードの代表的パターン
+- レビュー観点が書かれた設定・文書・命名規則（あれば）
+
+## Workflow
+
+1. 明示ルールを収集する
+   - README, docs, lint 設定, テスト方針, ディレクトリ構造を確認
+2. 暗黙パターンを収集する
+   - 繰り返し現れる命名、責務分離、UI/データ取得の置き方を確認
+3. ルールを正規化する
+   - `Rule`, `Why`, `How to Judge`, `Scope`, `Source`, `Default Severity`, `Exceptions` を定義
+4. 種別を分ける
+   - `Project-Specific` と `General Web App` に分離する
+5. 判定不能な精神論を落とす
+   - レビュー時に yes/no 判断しにくいものは open question に回す
+
+## Deliverables
+
+- `review-criteria-catalog.md`: 構造化したレビュー基準一覧
+- `open-questions.md`: 判定不能または根拠不足で保留した項目
+
+Reuse `assets/rule-catalog-template.md` when producing a reusable review criteria catalog.
+
+## Data Handling
+
+- 機密値や個人情報をルール例として転載しない
+- 長いコード全文ではなく、ルールの根拠だけ要約する
+- 単一事例しかないものは `inferred` と明記する
+
+## Quality Gates
+
+- [ ] 各ルールに判定基準がある
+- [ ] 各ルールに source または pattern 根拠がある
+- [ ] project-specific と general が分離されている
+- [ ] 精神論だけのルールを採用していない
+- [ ] review 時に severity 初期値を使える
+
+## Gotchas
+
+- **単発実装の過学習**: 1 箇所だけの書き方を project rule と断定しない
+- **精神論の混入**: 「わかりやすく書く」だけでは diff review の基準にならない
+- **一般論の混線**: React/Next.js の一般 best practice を project 固有規約と混ぜない
+- **根拠抜け**: 設定ファイルや既存パターンへの紐づけがないルールは弱い
+- **例外未定義**: 例外条件がないと diff-reviewer がノイズを出しやすい
+
+## Validation Loop
+
+1. **Collect**: 明示ルールと暗黙パターンを集める
+2. **Normalize**: 各ルールを判定可能な形式に変換する
+3. **Verify**:
+   - 曖昧語だけで終わっていないか
+   - rule source があるか
+   - project/general が分離されているか
+4. **Recover**:
+   - 根拠不足 → `inferred` 扱いに下げる
+   - 判定不能 → open question に移す
+   - 重複 → 1 ルールへ統合する

--- a/private-skill/review-criteria-suite/skills/rule-cataloger/assets/rule-catalog-template.md
+++ b/private-skill/review-criteria-suite/skills/rule-cataloger/assets/rule-catalog-template.md
@@ -1,0 +1,15 @@
+# Review Criteria Catalog
+
+## Project-Specific Rules
+
+| ID | Rule | Why | How to Judge | Source | Default Severity | Exceptions |
+|---|---|---|---|---|---|---|
+
+## General Web App Rules
+
+| ID | Rule | Why | How to Judge | Source | Default Severity | Exceptions |
+|---|---|---|---|---|---|---|
+
+## Open Questions
+
+- ここには根拠不足または判定不能で保留した項目を置く

--- a/results/skill-spec.md
+++ b/results/skill-spec.md
@@ -1,0 +1,44 @@
+# Agent Skills Development Specification
+
+## Objective
+Webアプリ開発におけるコーディングルールを明文化し、AI code reviewer が差分レビュー時に一貫した基準で指摘・整理できる suite を作る。
+
+## Domain & Audience
+- Domain: Webアプリ開発
+- Primary users: 自分 + AI code reviewer
+
+## Architecture
+- Type: Suite
+- Sub-skills:
+  - `rule-cataloger` — プロジェクトのコーディングルール・レビュー観点を収集して基準化する
+  - `diff-reviewer` — 差分をルールに照らしてレビューする
+  - `review-synthesizer` — 指摘を重要度・カテゴリごとに整理して返す
+- Custom Agents:
+  - `code-review-auditor` — 差分の事実確認に特化した読み取り中心のレビュー補助 Agent
+
+## Workflow Phases
+| Phase | Sub-skill | Description | Gate |
+|-------|-----------|-------------|------|
+| 0 | `rule-cataloger` | リポジトリ内の規約・既存パターン・レビュー観点を抽出してレビュー基準を定義する | auto |
+| 1 | `diff-reviewer` | 変更差分をレビュー基準に照らして問題候補を抽出する | auto |
+| 2 | `review-synthesizer` | 指摘を重要度・根拠・修正方針つきで整理する | ⏸️ |
+
+## Integrations
+- MCP: none
+- Databases: none
+
+## Reference Model
+- Based on: none explicitly specified
+
+## Quality Criteria
+- ルールが曖昧な精神論ではなく、レビュー時に判定できる基準として書かれている
+- AIレビュー結果に「なぜその指摘になるか」の根拠が含まれる
+- 指摘が重要度順に整理され、ノイズが少ない
+- プロジェクト固有ルールと一般的なWebアプリ開発ルールが区別されている
+- suite 全体でレビューの流れが `ルール確認 → 差分レビュー → 指摘整理` に一致している
+
+## Assumptions
+- suite 構成は、ユーザーが示した workflow に対応する 3 sub-skills を前提にした
+- 主用途は AI によるコードレビュー基準づくりであり、自動修正までは必須範囲に含めていない
+- MCP / 外部API / DB 連携は現時点では不要としている
+- 既存スキルを参照モデルとして固定せず、新規 suite として設計する前提にしている


### PR DESCRIPTION
review-criteria-suiteのskill追加

## 何をするのか

Webアプリ開発のレビュー依頼を、レビュー基準整理・差分レビュー・指摘整理の 3 phase に分けて扱う

レビュー基準が未整備な状態で diff レビューを始めてノイズが増える問題を避けるため、次の順で役割を分離する

1. `rule-cataloger` — リポジトリ固有の規約・既存実装パターン・レビュー観点を収集して基準化
2. `diff-reviewer` — 変更差分をレビュー基準に照らして問題候補を抽出
3. `review-synthesizer` — 指摘を重要度・カテゴリ・根拠・修正方針ごとに整理

## いつ使うのか

- レビュー基準の整備から差分レビューまでを一つの入口で扱いたいとき
- プロジェクト固有ルールを明文化してから PR / diff をレビューしたいとき
- raw findings を最終レビューコメント向けにノイズを抑えて整理したいとき
- end-to-end で `rule-cataloger` → `diff-reviewer` → `review-synthesizer` を使い分けたいとき