### PR TITLE
github-actionのsemver-系のパッケージエコシステムがサポートされないようで、削除

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 5
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
https://github.com/LeeDDHH/dev-resource/pull/342/checks?check_run_id=71983417099

Your .github/dependabot.yml contained invalid details Dependabot encountered the following error when parsing your .github/dependabot.yml:

The property '#/updates/0/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'. The property '#/updates/0/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'. The property '#/updates/0/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'. Please update the config file to conform with Dependabot's specification.